### PR TITLE
Create 5b3c136fd4b74f3fb2a366a254c76c9a.json

### DIFF
--- a/custom_components/jebao_aqua/models/5b3c136fd4b74f3fb2a366a254c76c9a.json
+++ b/custom_components/jebao_aqua/models/5b3c136fd4b74f3fb2a366a254c76c9a.json
@@ -1,0 +1,212 @@
+{
+  "product_key": "5b3c136fd4b74f3fb2a366a254c76c9a",
+  "name": "Doser 2.4 WiFi 4-Channel",
+  "attrs": [
+    {
+      "display_name": "Power Switch",
+      "name": "switch",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 0
+      },
+      "type": "status_writable",
+      "id": 0,
+      "desc": "Controls the power state of the pump."
+    },
+    {
+      "display_name": "Channel 1 Switch",
+      "name": "channe1",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 1
+      },
+      "type": "status_writable",
+      "id": 1,
+      "desc": "Manages Channel 1's manual switch."
+    },
+    {
+      "display_name": "Channel 2 Switch",
+      "name": "channe2",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 2
+      },
+      "type": "status_writable",
+      "id": 2,
+      "desc": "Manages Channel 2's manual switch."
+    },
+    {
+      "display_name": "Channel 3 Switch",
+      "name": "channe3",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 3
+      },
+      "type": "status_writable",
+      "id": 3,
+      "desc": "Manages Channel 3's manual switch."
+    },
+    {
+      "display_name": "Channel 4 Switch",
+      "name": "channe4",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 4
+      },
+      "type": "status_writable",
+      "id": 4,
+      "desc": "Manages Channel 4's manual switch."
+    },
+    {
+      "display_name": "Timer 1 Switch",
+      "name": "Timer1ON",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 5
+      },
+      "type": "status_writable",
+      "id": 5,
+      "desc": "Enables or disables Timer 1."
+    },
+    {
+      "display_name": "Timer 2 Switch",
+      "name": "Timer2ON",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 6
+      },
+      "type": "status_writable",
+      "id": 6,
+      "desc": "Enables or disables Timer 2."
+    },
+    {
+      "display_name": "Timer 3 Switch",
+      "name": "Timer3ON",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 7
+      },
+      "type": "status_writable",
+      "id": 7,
+      "desc": "Enables or disables Timer 3."
+    },
+    {
+      "display_name": "Timer 4 Switch",
+      "name": "Timer4ON",
+      "data_type": "bool",
+      "position": {
+        "byte_offset": 0,
+        "unit": "bit",
+        "len": 1,
+        "bit_offset": 8
+      },
+      "type": "status_writable",
+      "id": 8,
+      "desc": "Enables or disables Timer 4."
+    },
+    {
+      "display_name": "Interval Time 1",
+      "name": "IntervalT1",
+      "data_type": "uint8",
+      "position": {
+        "byte_offset": 2,
+        "unit": "byte",
+        "len": 1,
+        "bit_offset": 0
+      },
+      "uint_spec": {
+        "addition": 0,
+        "max": 30,
+        "ratio": 1,
+        "min": 0
+      },
+      "type": "status_writable",
+      "id": 11,
+      "desc": "Interval time for Channel 1."
+    },
+    {
+      "display_name": "Interval Time 2",
+      "name": "IntervalT2",
+      "data_type": "uint8",
+      "position": {
+        "byte_offset": 3,
+        "unit": "byte",
+        "len": 1,
+        "bit_offset": 0
+      },
+      "uint_spec": {
+        "addition": 0,
+        "max": 30,
+        "ratio": 1,
+        "min": 0
+      },
+      "type": "status_writable",
+      "id": 12,
+      "desc": "Interval time for Channel 2."
+    },
+        {
+      "display_name": "Interval Time 3",
+      "name": "IntervalT3",
+      "data_type": "uint8",
+      "position": {
+        "byte_offset": 3,
+        "unit": "byte",
+        "len": 1,
+        "bit_offset": 0
+      },
+      "uint_spec": {
+        "addition": 0,
+        "max": 30,
+        "ratio": 1,
+        "min": 0
+      },
+      "type": "status_writable",
+      "id": 12,
+      "desc": "Interval time for Channel 3."
+    },
+     {
+      "display_name": "Interval Time 4",
+      "name": "IntervalT4",
+      "data_type": "uint8",
+      "position": {
+        "byte_offset": 3,
+        "unit": "byte",
+        "len": 1,
+        "bit_offset": 0
+      },
+      "uint_spec": {
+        "addition": 0,
+        "max": 30,
+        "ratio": 1,
+        "min": 0
+      },
+      "type": "status_writable",
+      "id": 12,
+      "desc": "Interval time for Channel 4."
+    }
+  ]
+}


### PR DESCRIPTION
Jebao Doser 2.4 WiFi 4-Channel - The Jebao Doser 2.4 WiFi 4-Channel model uses the same code as the Jebao MD 4.4 Dosing Pumps (added by @jeffcybulski). I just changed the product key to make it work with this model. I added interval times for Channel 3 and Channel 4, and removed a dosing channel that wasn’t working properly with this doser until I figure out the issue."