### PR TITLE
Fix cloud-only mode: LAN-IP guard, config-flow None defaults, closed session on cloud polls

### DIFF
--- a/custom_components/jebao_aqua/__init__.py
+++ b/custom_components/jebao_aqua/__init__.py
@@ -161,7 +161,7 @@ class GizwitsDataUpdateCoordinator(DataUpdateCoordinator):
                 ),
                 None,
             )
-            if device_info and "lan_ip" in device_info:
+            if device_info and device_info.get("lan_ip"):
                 LOGGER.debug(
                     f"Getting local data for device {device_id} at {device_info['lan_ip']}"
                 )

--- a/custom_components/jebao_aqua/api.py
+++ b/custom_components/jebao_aqua/api.py
@@ -137,7 +137,7 @@ class GizwitsApi:
         }
         LOGGER.debug("Trying to get devices - Headers are: %s", headers)
         try:
-            async with self._session.get(
+            async with aiohttp.ClientSession() as _s, _s.get(
                 self.devices_url, headers=headers, timeout=TIMEOUT
             ) as response:
                 result = await response.text()
@@ -163,7 +163,7 @@ class GizwitsApi:
             "Accept": "application/json",
         }
         try:
-            async with self._session.get(
+            async with aiohttp.ClientSession() as _s, _s.get(
                 url, headers=headers, timeout=TIMEOUT
             ) as response:
                 result = await response.text()

--- a/custom_components/jebao_aqua/config_flow.py
+++ b/custom_components/jebao_aqua/config_flow.py
@@ -194,7 +194,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema[
                 vol.Optional(
                     alias,
-                    default=device.get("lan_ip", ""),
+                    default=device.get("lan_ip") or "",
                 )
             ] = str
 
@@ -425,7 +425,7 @@ class JebaoPumpOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema[
                 vol.Optional(
                     alias,
-                    default=device.get("lan_ip", ""),
+                    default=device.get("lan_ip") or "",
                 )
             ] = str
 

--- a/custom_components/jebao_aqua/const.py
+++ b/custom_components/jebao_aqua/const.py
@@ -39,7 +39,7 @@ LAN_PORT = 12416
 # Update interval
 from datetime import timedelta
 
-UPDATE_INTERVAL = timedelta(seconds=2)
+UPDATE_INTERVAL = timedelta(seconds=30)
 
 # Platform types
 PLATFORMS = ["switch", "sensor", "select", "number"]


### PR DESCRIPTION
The README's "leave IPs blank for cloud-only mode" path is currently broken end-to-end. I run 6 Jebao/Jecod devices on a network segment with **no route from Home Assistant** (isolated 2.4GHz IoT network behind a separate router), so cloud-only is the only viable mode. Three separate bugs prevent it from working; this PR fixes all three, plus a poll-interval tweak. Tested on HA 2026.7 / Python 3.14 with 6 devices (3x Jecod D-Series WiFi+BLE wavemakers, 2x 4-channel dosers, 1x DC return pump): setup, 30s polling, control, and device-initiated state changes (feed mode, linkage secondary pause) all confirmed working over cloud only.

### Bug 1 - coordinator never falls back to cloud polling (`__init__.py`)

`fetch_initial_device_list` sets `device["lan_ip"] = None` for devices without an IP, so the key always exists. The update path checks key *presence*, not value (`if device_info and "lan_ip" in device_info:`) - True even when `lan_ip` is None. Every "cloud" device therefore attempts a local connection to None, fails, and serves stale cached data forever (`Using cached data for device ...` every cycle). Fixed to `device_info.get("lan_ip")`.

### Bug 2 - config flow rejects blank IP fields (`config_flow.py`, two places)

When discovery times out (guaranteed on isolated networks), devices carry `lan_ip = None`, and the schema builds `vol.Optional(alias, default=None)` against `str` - submitting with blank fields fails validation with `expected str` on every device. Same pattern in the options flow. Fixed to `default=device.get("lan_ip") or ""`.

### Bug 3 - cloud polls fail with "Session is closed" (`api.py`)

`async_setup_entry` wraps setup in `async with api:`; when setup returns, `__aexit__` closes the shared aiohttp session. Every subsequent cloud poll then raises `Session is closed`. Local polling never hits this (own TCP connection) and `control_device` already creates a fresh `ClientSession` per call - which is why cloud *control* works while cloud *polling* doesn't. Minimal fix, matching the existing control pattern: a fresh `ClientSession` per GET.

*Alternative you may prefer:* drop the hand-rolled `self._session` entirely and use HA's managed `async_get_clientsession(hass)` for login + polls + control. Happy to rework the PR that way if you'd rather.

### 4 - poll interval for cloud mode (`const.py`)

`UPDATE_INTERVAL = timedelta(seconds=2)` is reasonable on LAN but aggressive against the Gizwits API (6 devices ~= 260k requests/day). Bumped the default to 30s; a cleaner follow-up would be a per-entry `scan_interval` option (2s local / 30s cloud).

### Verification performed

- Config flow with **all IP fields blank** completes; 6 devices, 124 entities created.
- - No `Session is closed` / `Using cached data` after fix; clean 30s polling.
- - Control round-trip: switch off/on from HA physically actuates pumps (~1-2s).
- - Device-initiated changes reach HA without the mobile app running: a linkage Secondary flipping its own FeedSwitch when its Primary was switched off was captured by the next poll.
### Minor issues noticed (not fixed here, can file separately)

- Entities set invalid entity_ids when device aliases contain hyphens (`number.aq-x-4doser_...`) - HA warns this breaks in 2027.2.0; `create_entity_id` should slugify.
- - `load_attribute_models` calls `models_path.glob()` in the event loop - HA flags blocking `scandir`; wrap in `hass.async_add_executor_job`.
Context: these devices are the newer WiFi+BLE (ESP32-C3) hardware generation; see issue #47. Cloud path behaves identically to the older ESP8266 units - the fixes above are what make cloud-only mode actually work.