### PR TITLE
feat: add doser schedule service (set_doser_schedule) for LAN and cloud devices

### DIFF
--- a/custom_components/jebao_aqua/__init__.py
+++ b/custom_components/jebao_aqua/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 from pathlib import Path
@@ -25,6 +24,14 @@ from .const import (
     MODE_CLOUD,
     MODE_LOCAL,
     PLATFORMS,
+)
+from .doser_adjust import (
+    apply_volume_delta_to_slots as _alg_apply_volume_delta_to_slots,
+    new_slot_times as _alg_new_slot_times,
+    parse_schedule_from_attr as _alg_parse_schedule_from_attr,
+    pick_uniform_positions as _alg_pick_uniform_positions,
+    schedule_to_bytes as _alg_schedule_to_bytes,
+    slots_to_service_payload as _alg_slots_to_service_payload,
 )
 from .hub import JebaoDevice, _load_device_configs, async_discover_devices
 
@@ -177,64 +184,25 @@ def _build_schedule_blob(slots: list[dict]) -> bytes:
 
 def _schedule_to_bytes(raw: Any) -> bytes | None:
     """Normalize a CHxSWTime value to bytes."""
-    if raw is None:
-        return None
-    if isinstance(raw, (bytes, bytearray)):
-        return bytes(raw)
-    if isinstance(raw, str):
-        value = raw.strip()
-        try:
-            return bytes.fromhex(value)
-        except ValueError:
-            try:
-                return base64.b64decode(value, validate=True)
-            except Exception:
-                return None
-    return None
+    return _alg_schedule_to_bytes(raw)
 
 
 def _parse_schedule_from_attr(raw: Any) -> list[dict[str, int]]:
     """Parse CHxSWTime payload into slot dictionaries sorted by time."""
-    data = _schedule_to_bytes(raw)
-    if not data or not any(data):
-        return []
-
-    parsed: list[dict[str, int]] = []
-    for i in range(0, min(len(data), SCHEDULE_BYTES_LEN) - 7, 8):
-        block = data[i : i + 8]
-        if not any(block):
-            break
-
-        for hour, minute, dose_ml in (
-            (block[0], block[1], block[3]),
-            (block[4], block[5], block[7]),
-        ):
-            if 0 <= hour <= 23 and 0 <= minute <= 59 and dose_ml > 0:
-                parsed.append(
-                    {"hour": int(hour), "minute": int(minute), "dose_ml": int(dose_ml)}
-                )
-
-    parsed.sort(key=lambda s: (s["hour"], s["minute"]))
-    return parsed
+    return _alg_parse_schedule_from_attr(raw, schedule_bytes_len=SCHEDULE_BYTES_LEN)
 
 
 def _pick_uniform_positions(total: int, pick: int) -> list[int]:
     """Pick evenly-spaced positions across a fixed-size list."""
-    if pick <= 0 or total <= 0:
-        return []
-    if pick >= total:
-        return list(range(total))
-    return [int(i * total / pick) for i in range(pick)]
+    return _alg_pick_uniform_positions(total, pick)
 
 
 def _new_slot_times(existing_slots: list[dict[str, int]], count: int) -> list[tuple[int, int]]:
     """Return uniformly spaced empty slot times for newly created entries."""
-    used = {(slot["hour"], slot["minute"]) for slot in existing_slots}
-    candidates = [(hour, 0) for hour in range(24) if (hour, 0) not in used]
-    if count > len(candidates):
-        raise HomeAssistantError("Not enough empty slot times available")
-    positions = _pick_uniform_positions(len(candidates), count)
-    return [candidates[pos] for pos in positions]
+    try:
+        return _alg_new_slot_times(existing_slots, count)
+    except ValueError as exc:
+        raise HomeAssistantError(str(exc)) from exc
 
 
 def _normalize_channels(
@@ -273,80 +241,22 @@ def _apply_volume_delta_to_slots(
     fill_empty_first: bool,
 ) -> list[dict[str, int]]:
     """Adjust slot doses by signed mL delta, preserving schedule ordering."""
-    slots = [dict(slot) for slot in current_slots]
-    if delta_ml == 0:
-        return slots
-
-    if delta_ml > 0:
-        remaining = delta_ml
-
-        if fill_empty_first and len(slots) < MAX_DOSER_SLOTS:
-            to_create = min(remaining, MAX_DOSER_SLOTS - len(slots))
-            for hour, minute in _new_slot_times(slots, to_create):
-                slots.append({"hour": hour, "minute": minute, "dose_ml": MIN_DOSER_SLOT_ML})
-            remaining -= to_create
-
-        if not slots:
-            raise HomeAssistantError("Could not allocate schedule slots for positive delta")
-
-        idx = 0
-        while remaining > 0:
-            progressed = False
-            for _ in range(len(slots)):
-                pos = idx % len(slots)
-                idx += 1
-                if slots[pos]["dose_ml"] >= MAX_DOSER_SLOT_ML:
-                    continue
-                slots[pos]["dose_ml"] += 1
-                remaining -= 1
-                progressed = True
-                if remaining == 0:
-                    break
-            if not progressed:
-                raise HomeAssistantError(
-                    "Cannot apply positive delta: all slots reached maximum dose"
-                )
-
-        slots.sort(key=lambda s: (s["hour"], s["minute"]))
-        return slots
-
-    removal = abs(delta_ml)
-    total_volume = sum(slot["dose_ml"] for slot in slots)
-    if removal > total_volume:
-        raise HomeAssistantError(
-            f"Cannot remove {removal} mL from schedule with total {total_volume} mL"
+    try:
+        return _alg_apply_volume_delta_to_slots(
+            current_slots=current_slots,
+            delta_ml=delta_ml,
+            fill_empty_first=fill_empty_first,
+            max_doser_slots=MAX_DOSER_SLOTS,
+            min_slot_ml=MIN_DOSER_SLOT_ML,
+            max_slot_ml=MAX_DOSER_SLOT_ML,
         )
-
-    if not slots:
-        raise HomeAssistantError("Cannot apply negative delta to an empty schedule")
-
-    idx = 0
-    while removal > 0:
-        for _ in range(len(slots)):
-            pos = idx % len(slots)
-            idx += 1
-            if slots[pos]["dose_ml"] <= 0:
-                continue
-            slots[pos]["dose_ml"] -= 1
-            removal -= 1
-            if removal == 0:
-                break
-
-    slots = [slot for slot in slots if slot["dose_ml"] > 0]
-    slots.sort(key=lambda s: (s["hour"], s["minute"]))
-    return slots
+    except ValueError as exc:
+        raise HomeAssistantError(str(exc)) from exc
 
 
 def _slots_to_service_payload(slots: list[dict[str, int]]) -> list[dict[str, int]]:
     """Convert parsed slots back to the writer payload shape."""
-    return [
-        {
-            "hour": slot["hour"],
-            "minute": slot["minute"],
-            "dose_ml": slot["dose_ml"],
-        }
-        for slot in slots
-    ]
+    return _alg_slots_to_service_payload(slots)
 
 
 def _resolve_target_from_entity_id(

--- a/custom_components/jebao_aqua/__init__.py
+++ b/custom_components/jebao_aqua/__init__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from pathlib import Path
 import re
+from typing import Any
 
 import voluptuous as vol
 
@@ -31,10 +33,13 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG_ENTRY_VERSION = 2
 # Service name exposed as jebao_aqua.set_doser_schedule
 SERVICE_SET_DOSER_SCHEDULE = "set_doser_schedule"
+SERVICE_ADJUST_DOSER_SCHEDULE_TOTAL = "adjust_doser_schedule_total"
 # CHxSWTime uses a fixed 96-byte payload in all known doser models.
 SCHEDULE_BYTES_LEN = 96
 # 96 bytes = 12 blocks * 8 bytes, each block holds 2 schedule slots.
 MAX_DOSER_SLOTS = 24
+MIN_DOSER_SLOT_ML = 1
+MAX_DOSER_SLOT_ML = 255
 
 
 def _validate_schedule_service_target(data: dict) -> dict:
@@ -45,6 +50,23 @@ def _validate_schedule_service_target(data: dict) -> dict:
     # For UID-only calls we cannot infer the channel, so require it explicitly.
     if data.get("device_uid") and not data.get("entity_id") and "channel" not in data:
         raise vol.Invalid("channel is required when entity_id is not provided")
+    return data
+
+
+def _validate_adjust_service_request(data: dict) -> dict:
+    """Validate request shape for doser total adjustments."""
+    if not data.get("device_uid") and not data.get("entity_id"):
+        raise vol.Invalid("Either device_uid or entity_id is required")
+
+    has_channel = "channel" in data
+    has_channels = "channels" in data
+    if has_channel and has_channels:
+        raise vol.Invalid("Use either channel or channels, not both")
+
+    has_delta_ml = "delta_ml" in data
+    has_delta_percent = "delta_percent" in data
+    if has_delta_ml == has_delta_percent:
+        raise vol.Invalid("Provide exactly one of delta_ml or delta_percent")
     return data
 
 
@@ -62,6 +84,28 @@ SET_DOSER_SCHEDULE_SCHEMA = vol.All(
         }
     ),
     _validate_schedule_service_target,
+)
+
+
+ADJUST_DOSER_SCHEDULE_TOTAL_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Optional("device_uid"): cv.string,
+            vol.Optional("entity_id"): cv.entity_id,
+            vol.Optional("channel"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+            vol.Optional("channels"): [
+                vol.All(vol.Coerce(int), vol.Range(min=1, max=8))
+            ],
+            vol.Optional("delta_ml"): vol.Coerce(int),
+            vol.Optional("delta_percent"): vol.Coerce(float),
+            vol.Optional("fill_empty_first", default=True): cv.boolean,
+            vol.Optional("enable_timer"): cv.boolean,
+            vol.Optional("interval_days"): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=30)
+            ),
+        }
+    ),
+    _validate_adjust_service_request,
 )
 
 
@@ -129,6 +173,180 @@ def _build_schedule_blob(slots: list[dict]) -> bytes:
         payload[base + 3] = ml
 
     return bytes(payload)
+
+
+def _schedule_to_bytes(raw: Any) -> bytes | None:
+    """Normalize a CHxSWTime value to bytes."""
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray)):
+        return bytes(raw)
+    if isinstance(raw, str):
+        value = raw.strip()
+        try:
+            return bytes.fromhex(value)
+        except ValueError:
+            try:
+                return base64.b64decode(value, validate=True)
+            except Exception:
+                return None
+    return None
+
+
+def _parse_schedule_from_attr(raw: Any) -> list[dict[str, int]]:
+    """Parse CHxSWTime payload into slot dictionaries sorted by time."""
+    data = _schedule_to_bytes(raw)
+    if not data or not any(data):
+        return []
+
+    parsed: list[dict[str, int]] = []
+    for i in range(0, min(len(data), SCHEDULE_BYTES_LEN) - 7, 8):
+        block = data[i : i + 8]
+        if not any(block):
+            break
+
+        for hour, minute, dose_ml in (
+            (block[0], block[1], block[3]),
+            (block[4], block[5], block[7]),
+        ):
+            if 0 <= hour <= 23 and 0 <= minute <= 59 and dose_ml > 0:
+                parsed.append(
+                    {"hour": int(hour), "minute": int(minute), "dose_ml": int(dose_ml)}
+                )
+
+    parsed.sort(key=lambda s: (s["hour"], s["minute"]))
+    return parsed
+
+
+def _pick_uniform_positions(total: int, pick: int) -> list[int]:
+    """Pick evenly-spaced positions across a fixed-size list."""
+    if pick <= 0 or total <= 0:
+        return []
+    if pick >= total:
+        return list(range(total))
+    return [int(i * total / pick) for i in range(pick)]
+
+
+def _new_slot_times(existing_slots: list[dict[str, int]], count: int) -> list[tuple[int, int]]:
+    """Return uniformly spaced empty slot times for newly created entries."""
+    used = {(slot["hour"], slot["minute"]) for slot in existing_slots}
+    candidates = [(hour, 0) for hour in range(24) if (hour, 0) not in used]
+    if count > len(candidates):
+        raise HomeAssistantError("Not enough empty slot times available")
+    positions = _pick_uniform_positions(len(candidates), count)
+    return [candidates[pos] for pos in positions]
+
+
+def _normalize_channels(
+    data: dict[str, Any], inferred_channel: int | None
+) -> list[int]:
+    """Resolve requested channels from channel/channels/entity inference."""
+    channels: list[int]
+    if data.get("channels"):
+        channels = [int(ch) for ch in data["channels"]]
+    elif data.get("channel") is not None:
+        channels = [int(data["channel"])]
+    elif inferred_channel is not None:
+        channels = [inferred_channel]
+    else:
+        raise HomeAssistantError(
+            "channel/channels is required when channel cannot be inferred from entity_id"
+        )
+
+    if inferred_channel is not None and data.get("channels"):
+        if inferred_channel not in channels:
+            raise HomeAssistantError(
+                "Selected entity channel does not match the provided channels"
+            )
+
+    # Keep order and remove duplicates.
+    unique_channels: list[int] = []
+    for ch in channels:
+        if ch not in unique_channels:
+            unique_channels.append(ch)
+    return unique_channels
+
+
+def _apply_volume_delta_to_slots(
+    current_slots: list[dict[str, int]],
+    delta_ml: int,
+    fill_empty_first: bool,
+) -> list[dict[str, int]]:
+    """Adjust slot doses by signed mL delta, preserving schedule ordering."""
+    slots = [dict(slot) for slot in current_slots]
+    if delta_ml == 0:
+        return slots
+
+    if delta_ml > 0:
+        remaining = delta_ml
+
+        if fill_empty_first and len(slots) < MAX_DOSER_SLOTS:
+            to_create = min(remaining, MAX_DOSER_SLOTS - len(slots))
+            for hour, minute in _new_slot_times(slots, to_create):
+                slots.append({"hour": hour, "minute": minute, "dose_ml": MIN_DOSER_SLOT_ML})
+            remaining -= to_create
+
+        if not slots:
+            raise HomeAssistantError("Could not allocate schedule slots for positive delta")
+
+        idx = 0
+        while remaining > 0:
+            progressed = False
+            for _ in range(len(slots)):
+                pos = idx % len(slots)
+                idx += 1
+                if slots[pos]["dose_ml"] >= MAX_DOSER_SLOT_ML:
+                    continue
+                slots[pos]["dose_ml"] += 1
+                remaining -= 1
+                progressed = True
+                if remaining == 0:
+                    break
+            if not progressed:
+                raise HomeAssistantError(
+                    "Cannot apply positive delta: all slots reached maximum dose"
+                )
+
+        slots.sort(key=lambda s: (s["hour"], s["minute"]))
+        return slots
+
+    removal = abs(delta_ml)
+    total_volume = sum(slot["dose_ml"] for slot in slots)
+    if removal > total_volume:
+        raise HomeAssistantError(
+            f"Cannot remove {removal} mL from schedule with total {total_volume} mL"
+        )
+
+    if not slots:
+        raise HomeAssistantError("Cannot apply negative delta to an empty schedule")
+
+    idx = 0
+    while removal > 0:
+        for _ in range(len(slots)):
+            pos = idx % len(slots)
+            idx += 1
+            if slots[pos]["dose_ml"] <= 0:
+                continue
+            slots[pos]["dose_ml"] -= 1
+            removal -= 1
+            if removal == 0:
+                break
+
+    slots = [slot for slot in slots if slot["dose_ml"] > 0]
+    slots.sort(key=lambda s: (s["hour"], s["minute"]))
+    return slots
+
+
+def _slots_to_service_payload(slots: list[dict[str, int]]) -> list[dict[str, int]]:
+    """Convert parsed slots back to the writer payload shape."""
+    return [
+        {
+            "hour": slot["hour"],
+            "minute": slot["minute"],
+            "dose_ml": slot["dose_ml"],
+        }
+        for slot in slots
+    ]
 
 
 def _resolve_target_from_entity_id(
@@ -208,9 +426,6 @@ async def _refresh_device_state(device: JebaoDevice | JebaoCloudDevice) -> None:
 
 def _async_register_services(hass: HomeAssistant) -> None:
     """Register integration-level services once."""
-    if hass.services.has_service(DOMAIN, SERVICE_SET_DOSER_SCHEDULE):
-        return
-
     async def _async_handle_set_doser_schedule(call: ServiceCall) -> None:
         # Validate and normalize service data once at entry.
         data = SET_DOSER_SCHEDULE_SCHEMA(dict(call.data))
@@ -278,18 +493,118 @@ def _async_register_services(hass: HomeAssistant) -> None:
         # Trigger a refresh so sensors reflect the new schedule quickly.
         await _refresh_device_state(device)
 
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_DOSER_SCHEDULE,
-        _async_handle_set_doser_schedule,
-        schema=SET_DOSER_SCHEDULE_SCHEMA,
-    )
+    async def _async_handle_adjust_doser_schedule_total(call: ServiceCall) -> None:
+        """Adjust total doser volume by absolute mL or percentage."""
+        data = ADJUST_DOSER_SCHEDULE_TOTAL_SCHEMA(dict(call.data))
+        device_uid = data.get("device_uid")
+        inferred_channel: int | None = None
+
+        if data.get("entity_id"):
+            uid_from_entity, channel_from_entity = _resolve_target_from_entity_id(
+                hass, data["entity_id"]
+            )
+            if device_uid and device_uid != uid_from_entity:
+                raise HomeAssistantError(
+                    "device_uid does not match the selected entity_id device"
+                )
+            device_uid = uid_from_entity
+            inferred_channel = channel_from_entity
+
+        if not device_uid:
+            raise HomeAssistantError("Could not resolve target device")
+
+        channels = _normalize_channels(data, inferred_channel)
+        fill_empty_first = bool(data.get("fill_empty_first", True))
+
+        device = _find_device_by_uid(hass, device_uid)
+        attr_names = {
+            attr.get("name")
+            for attr in getattr(device.giz_device, "all_attrs", [])
+            if isinstance(attr, dict)
+        }
+
+        plan: list[dict[str, Any]] = []
+        for channel in channels:
+            schedule_attr = f"CH{channel}SWTime"
+            if schedule_attr not in attr_names:
+                raise HomeAssistantError(
+                    f"Device {device_uid} does not support {schedule_attr}"
+                )
+
+            current_slots = _parse_schedule_from_attr(device.get_attribute(schedule_attr))
+            current_total = sum(slot["dose_ml"] for slot in current_slots)
+
+            if "delta_ml" in data:
+                delta_ml = int(data["delta_ml"])
+            else:
+                delta_ml = int(round(current_total * float(data["delta_percent"]) / 100.0))
+
+            if delta_ml == 0:
+                raise HomeAssistantError(
+                    f"Computed delta is 0 mL for channel {channel}; no schedule update generated"
+                )
+
+            adjusted_slots = _apply_volume_delta_to_slots(
+                current_slots=current_slots,
+                delta_ml=delta_ml,
+                fill_empty_first=fill_empty_first,
+            )
+            payload_hex = _build_schedule_blob(_slots_to_service_payload(adjusted_slots)).hex()
+            plan.append(
+                {
+                    "channel": channel,
+                    "schedule_attr": schedule_attr,
+                    "payload_hex": payload_hex,
+                }
+            )
+
+            if "interval_days" in data:
+                interval_attr = f"IntervalT{channel}"
+                if interval_attr not in attr_names:
+                    raise HomeAssistantError(
+                        f"Device {device_uid} does not support {interval_attr}"
+                    )
+
+        # Execute writes only after all channels validated (all-or-nothing).
+        for item in plan:
+            await device.async_set_attribute(item["schedule_attr"], item["payload_hex"])
+
+            channel = item["channel"]
+            if "interval_days" in data:
+                await device.async_set_attribute(
+                    f"IntervalT{channel}", int(data["interval_days"])
+                )
+
+            if "enable_timer" in data:
+                timer_attr = f"Timer{channel}ON"
+                if timer_attr in attr_names:
+                    await device.async_set_attribute(timer_attr, bool(data["enable_timer"]))
+
+        await _refresh_device_state(device)
+
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_DOSER_SCHEDULE):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_DOSER_SCHEDULE,
+            _async_handle_set_doser_schedule,
+            schema=SET_DOSER_SCHEDULE_SCHEMA,
+        )
+
+    if not hass.services.has_service(DOMAIN, SERVICE_ADJUST_DOSER_SCHEDULE_TOTAL):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_ADJUST_DOSER_SCHEDULE_TOTAL,
+            _async_handle_adjust_doser_schedule_total,
+            schema=ADJUST_DOSER_SCHEDULE_TOTAL_SCHEMA,
+        )
 
 
 def _async_unregister_services(hass: HomeAssistant) -> None:
     """Remove integration services when the last entry unloads."""
     if hass.services.has_service(DOMAIN, SERVICE_SET_DOSER_SCHEDULE):
         hass.services.async_remove(DOMAIN, SERVICE_SET_DOSER_SCHEDULE)
+    if hass.services.has_service(DOMAIN, SERVICE_ADJUST_DOSER_SCHEDULE_TOTAL):
+        hass.services.async_remove(DOMAIN, SERVICE_ADJUST_DOSER_SCHEDULE_TOTAL)
 
 
 def _did_to_uid(did: str) -> str:

--- a/custom_components/jebao_aqua/__init__.py
+++ b/custom_components/jebao_aqua/__init__.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+import re
+
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .cloud import GizwitsCloudApi, JebaoCloudDevice, parse_channel_names
@@ -25,6 +29,267 @@ from .hub import JebaoDevice, _load_device_configs, async_discover_devices
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_ENTRY_VERSION = 2
+# Service name exposed as jebao_aqua.set_doser_schedule
+SERVICE_SET_DOSER_SCHEDULE = "set_doser_schedule"
+# CHxSWTime uses a fixed 96-byte payload in all known doser models.
+SCHEDULE_BYTES_LEN = 96
+# 96 bytes = 12 blocks * 8 bytes, each block holds 2 schedule slots.
+MAX_DOSER_SLOTS = 24
+
+
+def _validate_schedule_service_target(data: dict) -> dict:
+    """Validate target/channel requirements for schedule writes."""
+    if not data.get("device_uid") and not data.get("entity_id"):
+        raise vol.Invalid("Either device_uid or entity_id is required")
+
+    # For UID-only calls we cannot infer the channel, so require it explicitly.
+    if data.get("device_uid") and not data.get("entity_id") and "channel" not in data:
+        raise vol.Invalid("channel is required when entity_id is not provided")
+    return data
+
+
+SET_DOSER_SCHEDULE_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Optional("device_uid"): cv.string,
+            vol.Optional("entity_id"): cv.entity_id,
+            vol.Optional("channel"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+            vol.Required("slots"): [dict],
+            vol.Optional("enable_timer"): cv.boolean,
+            vol.Optional("interval_days"): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=30)
+            ),
+        }
+    ),
+    _validate_schedule_service_target,
+)
+
+
+def _parse_schedule_slot(slot: dict, index: int) -> tuple[int, int, int]:
+    """Validate and normalize a schedule slot entry."""
+    if not isinstance(slot, dict):
+        raise HomeAssistantError(f"Slot {index} must be an object")
+
+    ml_raw = slot.get("dose_ml", slot.get("ml"))
+    if ml_raw is None:
+        raise HomeAssistantError(f"Slot {index} requires ml or dose_ml")
+    try:
+        ml = int(ml_raw)
+    except (TypeError, ValueError) as exc:
+        raise HomeAssistantError(f"Slot {index} has invalid ml value") from exc
+    if not 1 <= ml <= 255:
+        raise HomeAssistantError(f"Slot {index} ml must be between 1 and 255")
+
+    time_raw = slot.get("time")
+    if time_raw is not None:
+        if not isinstance(time_raw, str) or ":" not in time_raw:
+            raise HomeAssistantError(f"Slot {index} time must be HH:MM")
+        hh, mm = time_raw.split(":", 1)
+        try:
+            hour = int(hh)
+            minute = int(mm)
+        except ValueError as exc:
+            raise HomeAssistantError(f"Slot {index} time must be HH:MM") from exc
+    else:
+        if "hour" not in slot or "minute" not in slot:
+            raise HomeAssistantError(
+                f"Slot {index} requires time or both hour and minute"
+            )
+        try:
+            hour = int(slot["hour"])
+            minute = int(slot["minute"])
+        except (TypeError, ValueError) as exc:
+            raise HomeAssistantError(
+                f"Slot {index} hour/minute must be integers"
+            ) from exc
+
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+        raise HomeAssistantError(f"Slot {index} has invalid time {hour:02d}:{minute:02d}")
+
+    return hour, minute, ml
+
+
+def _build_schedule_blob(slots: list[dict]) -> bytes:
+    """Encode up to 24 schedule slots into the CHxSWTime 96-byte payload."""
+    if len(slots) > MAX_DOSER_SLOTS:
+        raise HomeAssistantError(
+            f"Maximum {MAX_DOSER_SLOTS} slots are supported per channel"
+        )
+
+    payload = bytearray(SCHEDULE_BYTES_LEN)
+    for idx, slot in enumerate(slots):
+        hour, minute, ml = _parse_schedule_slot(slot, idx + 1)
+        # Two slots are packed per 8-byte block: [h,m,0,ml, h,m,0,ml].
+        pair = idx // 2
+        in_pair_offset = 0 if idx % 2 == 0 else 4
+        base = pair * 8 + in_pair_offset
+        payload[base] = hour
+        payload[base + 1] = minute
+        payload[base + 2] = 0
+        payload[base + 3] = ml
+
+    return bytes(payload)
+
+
+def _resolve_target_from_entity_id(
+    hass: HomeAssistant, entity_id: str
+) -> tuple[str, int | None]:
+    """Resolve target device UID and (when possible) channel from an entity."""
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(entity_id)
+    if entry is None:
+        raise HomeAssistantError(f"Entity {entity_id} was not found")
+    if not entry.unique_id or "_" not in entry.unique_id:
+        raise HomeAssistantError(
+            f"Entity {entity_id} does not expose a parsable unique_id"
+        )
+    try:
+        uid, attr_name, _platform = entry.unique_id.rsplit("_", 2)
+    except ValueError as exc:
+        raise HomeAssistantError(
+            f"Entity {entity_id} does not expose a parsable unique_id"
+        ) from exc
+    if not uid:
+        raise HomeAssistantError(f"Could not extract device UID from {entity_id}")
+
+    # Infer channel from common doser attribute naming patterns so selecting an
+    # entity in the UI usually removes the need to manually set channel.
+    inferred_channel: int | None = None
+    channel_patterns = (
+        r"^CH([1-8])(?:Schedule|Volume)$",  # derived HA schedule/volume sensors
+        r"^CH([1-8])SWTime$",               # raw schedule datapoint
+        r"^channe([1-8])$",                 # model typo used by the device defs
+        r"^Timer([1-8])ON$",                # per-channel timer switch
+        r"^IntervalT([1-8])$",              # per-channel pause-days number
+    )
+    for pattern in channel_patterns:
+        match = re.match(pattern, attr_name)
+        if match:
+            inferred_channel = int(match.group(1))
+            break
+    return uid, inferred_channel
+
+
+def _get_loaded_devices(hass: HomeAssistant) -> list[JebaoDevice | JebaoCloudDevice]:
+    """Collect all currently loaded devices across config entries."""
+    devices: list[JebaoDevice | JebaoCloudDevice] = []
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.runtime_data:
+            devices.extend(entry.runtime_data)
+    return devices
+
+
+def _find_device_by_uid(
+    hass: HomeAssistant, device_uid: str
+) -> JebaoDevice | JebaoCloudDevice:
+    """Return the loaded device matching the requested UID."""
+    for device in _get_loaded_devices(hass):
+        if getattr(device, "uid", None) == device_uid:
+            return device
+    raise HomeAssistantError(
+        f"Device UID {device_uid} is not loaded by the {DOMAIN} integration"
+    )
+
+
+async def _refresh_device_state(device: JebaoDevice | JebaoCloudDevice) -> None:
+    """Best-effort refresh so entities reflect schedule changes quickly."""
+    try:
+        if hasattr(device, "request_status_update"):
+            # Cloud wrapper and some device wrappers expose this directly.
+            await device.request_status_update()
+            return
+        giz_device = getattr(device, "giz_device", None)
+        if giz_device and hasattr(giz_device, "request_status_update"):
+            # LAN device path: refresh through underlying protocol device.
+            await giz_device.request_status_update()
+    except Exception as exc:
+        _LOGGER.debug("Could not refresh device status after schedule update: %s", exc)
+
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register integration-level services once."""
+    if hass.services.has_service(DOMAIN, SERVICE_SET_DOSER_SCHEDULE):
+        return
+
+    async def _async_handle_set_doser_schedule(call: ServiceCall) -> None:
+        # Validate and normalize service data once at entry.
+        data = SET_DOSER_SCHEDULE_SCHEMA(dict(call.data))
+        device_uid = data.get("device_uid")
+        channel = data.get("channel")
+
+        if data.get("entity_id"):
+            # Allow targeting by any integration entity from the same device,
+            # while auto-selecting the channel for CHx schedule/volume sensors.
+            uid_from_entity, channel_from_entity = _resolve_target_from_entity_id(
+                hass, data["entity_id"]
+            )
+            if device_uid and device_uid != uid_from_entity:
+                raise HomeAssistantError(
+                    "device_uid does not match the selected entity_id device"
+                )
+            device_uid = uid_from_entity
+
+            if channel_from_entity is not None:
+                if channel is not None and channel != channel_from_entity:
+                    raise HomeAssistantError(
+                        "Selected entity channel does not match the provided channel"
+                    )
+                channel = channel_from_entity
+
+        if not device_uid:
+            raise HomeAssistantError("Could not resolve target device")
+        if channel is None:
+            raise HomeAssistantError(
+                "channel is required when it cannot be inferred from entity_id"
+            )
+
+        attr_name = f"CH{channel}SWTime"
+        # Encode to hex so both LAN and cloud writers can consume it.
+        payload_hex = _build_schedule_blob(data["slots"]).hex()
+
+        device = _find_device_by_uid(hass, device_uid)
+        attr_names = {
+            attr.get("name")
+            for attr in getattr(device.giz_device, "all_attrs", [])
+            if isinstance(attr, dict)
+        }
+        if attr_name not in attr_names:
+            raise HomeAssistantError(
+                f"Device {device_uid} does not support {attr_name}"
+            )
+
+        # Main write: replace the full channel schedule in one command.
+        await device.async_set_attribute(attr_name, payload_hex)
+
+        if "interval_days" in data:
+            interval_attr = f"IntervalT{channel}"
+            if interval_attr not in attr_names:
+                raise HomeAssistantError(
+                    f"Device {device_uid} does not support {interval_attr}"
+                )
+            await device.async_set_attribute(interval_attr, int(data["interval_days"]))
+
+        if "enable_timer" in data:
+            timer_attr = f"Timer{channel}ON"
+            if timer_attr in attr_names:
+                # Optional convenience write to align timer mode with schedule changes.
+                await device.async_set_attribute(timer_attr, bool(data["enable_timer"]))
+
+        # Trigger a refresh so sensors reflect the new schedule quickly.
+        await _refresh_device_state(device)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_DOSER_SCHEDULE,
+        _async_handle_set_doser_schedule,
+        schema=SET_DOSER_SCHEDULE_SCHEMA,
+    )
+
+
+def _async_unregister_services(hass: HomeAssistant) -> None:
+    """Remove integration services when the last entry unloads."""
+    if hass.services.has_service(DOMAIN, SERVICE_SET_DOSER_SCHEDULE):
+        hass.services.async_remove(DOMAIN, SERVICE_SET_DOSER_SCHEDULE)
 
 
 def _did_to_uid(did: str) -> str:
@@ -176,8 +441,13 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
     if entry.data.get(CONF_MODE, MODE_LOCAL) == MODE_CLOUD:
-        return await _async_setup_cloud(hass, entry)
-    return await _async_setup_local(hass, entry)
+        setup_ok = await _async_setup_cloud(hass, entry)
+    else:
+        setup_ok = await _async_setup_local(hass, entry)
+
+    if setup_ok:
+        _async_register_services(hass)
+    return setup_ok
 
 
 async def _async_setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -425,6 +695,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for device in devices:
             await device.async_disconnect()
         entry.runtime_data = None
+
+        other_loaded = any(
+            e.entry_id != entry.entry_id and e.runtime_data
+            for e in hass.config_entries.async_entries(DOMAIN)
+        )
+        if not other_loaded:
+            _async_unregister_services(hass)
 
     return unload_ok
 

--- a/custom_components/jebao_aqua/doser_adjust.py
+++ b/custom_components/jebao_aqua/doser_adjust.py
@@ -1,0 +1,157 @@
+"""Pure schedule adjustment helpers for doser services.
+
+This module intentionally avoids Home Assistant imports so logic can be
+unit-tested in isolation.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+
+def schedule_to_bytes(raw: Any) -> bytes | None:
+    """Normalize a CHxSWTime value to bytes."""
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray)):
+        return bytes(raw)
+    if isinstance(raw, str):
+        value = raw.strip()
+        try:
+            return bytes.fromhex(value)
+        except ValueError:
+            try:
+                return base64.b64decode(value, validate=True)
+            except Exception:
+                return None
+    return None
+
+
+def parse_schedule_from_attr(raw: Any, schedule_bytes_len: int = 96) -> list[dict[str, int]]:
+    """Parse CHxSWTime payload into slot dictionaries sorted by time."""
+    data = schedule_to_bytes(raw)
+    if not data or not any(data):
+        return []
+
+    parsed: list[dict[str, int]] = []
+    for i in range(0, min(len(data), schedule_bytes_len) - 7, 8):
+        block = data[i : i + 8]
+        if not any(block):
+            break
+
+        for hour, minute, dose_ml in (
+            (block[0], block[1], block[3]),
+            (block[4], block[5], block[7]),
+        ):
+            if 0 <= hour <= 23 and 0 <= minute <= 59 and dose_ml > 0:
+                parsed.append(
+                    {"hour": int(hour), "minute": int(minute), "dose_ml": int(dose_ml)}
+                )
+
+    parsed.sort(key=lambda s: (s["hour"], s["minute"]))
+    return parsed
+
+
+def pick_uniform_positions(total: int, pick: int) -> list[int]:
+    """Pick evenly-spaced positions across a fixed-size list."""
+    if pick <= 0 or total <= 0:
+        return []
+    if pick >= total:
+        return list(range(total))
+    return [int(i * total / pick) for i in range(pick)]
+
+
+def new_slot_times(existing_slots: list[dict[str, int]], count: int) -> list[tuple[int, int]]:
+    """Return uniformly spaced empty slot times for newly created entries."""
+    used = {(slot["hour"], slot["minute"]) for slot in existing_slots}
+    candidates = [(hour, 0) for hour in range(24) if (hour, 0) not in used]
+    if count > len(candidates):
+        raise ValueError("Not enough empty slot times available")
+    positions = pick_uniform_positions(len(candidates), count)
+    return [candidates[pos] for pos in positions]
+
+
+def apply_volume_delta_to_slots(
+    current_slots: list[dict[str, int]],
+    delta_ml: int,
+    fill_empty_first: bool,
+    max_doser_slots: int = 24,
+    min_slot_ml: int = 1,
+    max_slot_ml: int = 255,
+) -> list[dict[str, int]]:
+    """Adjust slot doses by signed mL delta, preserving schedule ordering."""
+    slots = [dict(slot) for slot in current_slots]
+    if delta_ml == 0:
+        return slots
+
+    if delta_ml > 0:
+        remaining = delta_ml
+
+        if fill_empty_first and len(slots) < max_doser_slots:
+            to_create = min(remaining, max_doser_slots - len(slots))
+            for hour, minute in new_slot_times(slots, to_create):
+                slots.append({"hour": hour, "minute": minute, "dose_ml": min_slot_ml})
+            remaining -= to_create
+
+        if not slots:
+            raise ValueError("Could not allocate schedule slots for positive delta")
+
+        idx = 0
+        while remaining > 0:
+            progressed = False
+            for _ in range(len(slots)):
+                pos = idx % len(slots)
+                idx += 1
+                if slots[pos]["dose_ml"] >= max_slot_ml:
+                    continue
+                slots[pos]["dose_ml"] += 1
+                remaining -= 1
+                progressed = True
+                if remaining == 0:
+                    break
+            if not progressed:
+                raise ValueError(
+                    "Cannot apply positive delta: all slots reached maximum dose"
+                )
+
+        slots.sort(key=lambda s: (s["hour"], s["minute"]))
+        return slots
+
+    removal = abs(delta_ml)
+    total_volume = sum(slot["dose_ml"] for slot in slots)
+    if removal > total_volume:
+        raise ValueError(
+            f"Cannot remove {removal} mL from schedule with total {total_volume} mL"
+        )
+
+    if not slots:
+        raise ValueError("Cannot apply negative delta to an empty schedule")
+
+    idx = 0
+    while removal > 0:
+        for _ in range(len(slots)):
+            pos = idx % len(slots)
+            idx += 1
+            if slots[pos]["dose_ml"] <= 0:
+                continue
+            slots[pos]["dose_ml"] -= 1
+            removal -= 1
+            if removal == 0:
+                break
+
+    slots = [slot for slot in slots if slot["dose_ml"] > 0]
+    slots.sort(key=lambda s: (s["hour"], s["minute"]))
+    return slots
+
+
+def slots_to_service_payload(slots: list[dict[str, int]]) -> list[dict[str, int]]:
+    """Convert parsed slots back to service payload shape."""
+    return [
+        {
+            "hour": slot["hour"],
+            "minute": slot["minute"],
+            "dose_ml": slot["dose_ml"],
+        }
+        for slot in slots
+    ]

--- a/custom_components/jebao_aqua/services.yaml
+++ b/custom_components/jebao_aqua/services.yaml
@@ -1,0 +1,68 @@
+set_doser_schedule:
+  name: Set doser schedule
+  description: >-
+    Write a full dosing schedule to one channel (CHxSWTime) using up to 24 slots.
+    Slots are encoded into the device 96-byte binary payload.
+  fields:
+    device_uid:
+      name: Device UID
+      description: >-
+        Target device UID. Optional when entity_id is provided.
+      example: "33333230313130343735363436303131"
+      selector:
+        text:
+    entity_id:
+      name: Entity ID
+      description: >-
+        Any jebao_aqua entity of the target device. Optional when device_uid is provided.
+        If this is a channel schedule/volume sensor, the channel is inferred automatically.
+      selector:
+        entity:
+          integration: jebao_aqua
+    channel:
+      name: Channel
+      description: >-
+        Doser channel number. Optional when entity_id points to a channel-specific
+        schedule/volume entity.
+      required: false
+      example: 1
+      selector:
+        number:
+          min: 1
+          max: 8
+          step: 1
+          mode: box
+    slots:
+      name: Slots
+      description: >-
+        List of up to 24 slot objects. Each slot accepts either time (HH:MM) + ml,
+        or hour + minute + ml. Empty list clears the schedule.
+      required: true
+      example:
+        - time: "08:00"
+          ml: 12
+        - hour: 20
+          minute: 30
+          dose_ml: 8
+      selector:
+        object:
+    enable_timer:
+      name: Enable channel timer
+      description: >-
+        Optional. When provided and supported, updates TimerXON for this channel.
+      required: false
+      example: true
+      selector:
+        boolean:
+    interval_days:
+      name: Interval days
+      description: >-
+        Optional. Updates IntervalT{channel} in the same call (0-30).
+      required: false
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 30
+          step: 1
+          mode: box

--- a/custom_components/jebao_aqua/services.yaml
+++ b/custom_components/jebao_aqua/services.yaml
@@ -66,3 +66,100 @@ set_doser_schedule:
           max: 30
           step: 1
           mode: box
+
+adjust_doser_schedule_total:
+  name: Adjust doser schedule total
+  description: >-
+    Adjust the total dosed volume of one or more channels, then rewrite each
+    channel schedule (CHxSWTime). Positive deltas fill empty slots first,
+    then distribute increment round-robin.
+  fields:
+    device_uid:
+      name: Device UID
+      description: >-
+        Target device UID. Optional when entity_id is provided.
+      example: "33333230313130343735363436303131"
+      selector:
+        text:
+    entity_id:
+      name: Entity ID
+      description: >-
+        Any jebao_aqua entity of the target device. Optional when device_uid is provided.
+      selector:
+        entity:
+          integration: jebao_aqua
+    channel:
+      name: Single channel
+      description: >-
+        Target a single doser channel. Use either channel or channels.
+      required: false
+      example: 1
+      selector:
+        number:
+          min: 1
+          max: 8
+          step: 1
+          mode: box
+    channels:
+      name: Multiple channels
+      description: >-
+        Target multiple channels in one transactional request.
+      required: false
+      example: [1, 2, 3]
+      selector:
+        object:
+    delta_ml:
+      name: Delta mL
+      description: >-
+        Signed absolute adjustment in mL (e.g. +3 or -2).
+        Provide exactly one of delta_ml or delta_percent.
+      required: false
+      example: 3
+      selector:
+        number:
+          min: -1000
+          max: 1000
+          step: 1
+          mode: box
+    delta_percent:
+      name: Delta percent
+      description: >-
+        Signed relative adjustment in percent of current total
+        (e.g. 30 means +30%). Provide exactly one of delta_ml or delta_percent.
+      required: false
+      example: 30
+      selector:
+        number:
+          min: -100
+          max: 1000
+          step: 0.1
+          mode: box
+    fill_empty_first:
+      name: Fill empty slots first
+      description: >-
+        When true, positive deltas create new 1 mL slots before incrementing
+        existing slots.
+      required: false
+      example: true
+      selector:
+        boolean:
+    enable_timer:
+      name: Enable channel timer
+      description: >-
+        Optional. When provided and supported, updates TimerXON for each channel.
+      required: false
+      example: true
+      selector:
+        boolean:
+    interval_days:
+      name: Interval days
+      description: >-
+        Optional. Updates IntervalT{channel} for each channel (0-30).
+      required: false
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 30
+          step: 1
+          mode: box


### PR DESCRIPTION
Summary
This PR adds a new integration service to write full doser schedules per channel in a single call.

What is included

New service: jebao_aqua.set_doser_schedule
Service schema and UI fields in services.yaml
Validation for target resolution:
Supports device_uid or entity_id
Requires channel when it cannot be inferred
Slot parsing and normalization:
Accepts time (HH:MM) + ml, or hour + minute + ml
Supports dose_ml alias
Schedule encoding:
Encodes up to 24 slots into the 96-byte CHxSWTime payload
Optional companion writes in same call:
IntervalT{channel} via interval_days
Timer{channel}ON via enable_timer (if supported)
Post-write refresh to update entities faster
Service lifecycle handling:
Register on successful entry setup
Unregister when the last jebao_aqua entry unloads
Files changed

__init__.py
services.yaml
Compatibility and behavior

Keeps existing entity/platform behavior unchanged
Fails with clear Home Assistant errors for invalid slots, unsupported attributes, or inconsistent target/channel data
Works with both local/LAN and cloud-backed wrappers through existing async_set_attribute path
Testing performed

Manual validation of payload generation and argument checks
Verified branch diff contains only the service implementation files